### PR TITLE
修复连接崩溃在MX2 Flyme Android4.4.4

### DIFF
--- a/Smart Proxy X/src/main/AndroidManifest.xml
+++ b/Smart Proxy X/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <application
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"


### PR DESCRIPTION
在Android4.4.4下需要android.permission.ACCESS_NETWORK_STATE权限，否则在获取Session的时候抛异常，导致空指针崩溃
