### PR TITLE
Fix an NPE bug in NatSessionManager

### DIFF
--- a/app/src/main/java/me/smartproxy/core/NatSessionManager.java
+++ b/app/src/main/java/me/smartproxy/core/NatSessionManager.java
@@ -24,7 +24,7 @@ public class NatSessionManager {
         long now = System.nanoTime();
         for (int i = Sessions.size() - 1; i >= 0; i--) {
             NatSession session = Sessions.valueAt(i);
-            if (now - session.LastNanoTime > SESSION_TIMEOUT_NS) {
+            if (session != null && now - session.LastNanoTime > SESSION_TIMEOUT_NS) {
                 Sessions.removeAt(i);
             }
         }


### PR DESCRIPTION
I found this NPE the other day. My theory is:

TcpProxyServer will also access Sessions in another thread, thus it can have a race condition.

SparseArray size() code

```
    public int size() {
        if (mGarbage) {
            gc();
        }

        return mSize;
    }
```

In gc()

```
    private void gc() {
        // Log.e("SparseArray", "gc start with " + mSize);

        int n = mSize;
        int o = 0;
        int[] keys = mKeys;
        Object[] values = mValues;

        for (int i = 0; i < n; i++) {
            Object val = values[i];

            if (val != DELETED) {
                if (i != o) {
                    keys[o] = keys[i];
                    values[o] = val;
                    values[i] = null;
                }

                o++;
            }
        }

        mGarbage = false;
        mSize = o;

        // Log.e("SparseArray", "gc end with " + mSize);
    }
```

If two threads calls size() in the same time, one might trigger gc, and set mGarbage to false, but before it set the mSize to a new value, the other thread can get the old mSize. Then valueAt(i) might return null.
